### PR TITLE
Allow bucket to be set before it exists.

### DIFF
--- a/src/CodeCeption/Module/S3Filesystem.php
+++ b/src/CodeCeption/Module/S3Filesystem.php
@@ -47,8 +47,12 @@ class S3Filesystem extends Filesystem {
 	public function setBucket( $bucket ) {
 		$this->bucket = $bucket;
 
-		$region = $this->getBucketLocation();
-		$this->setRegion( $region );
+		if ( $this->doesBucketExist() ) {
+			$region = $this->getBucketLocation();
+			$this->setRegion( $region );
+		} else {
+			$this->setRegion();
+		}
 
 		return $this;
 	}


### PR DESCRIPTION
Without this it is impossible to use `doesBucketExist` to test whether a bucket needs to be created or removed.
