### PR TITLE
Fix PHP Fatal error due to Declaration of deleteFile function is not compatible with the function in parent class

### DIFF
--- a/src/S3Filesystem.php
+++ b/src/S3Filesystem.php
@@ -220,7 +220,7 @@ class S3Filesystem extends Filesystem {
 	 *
 	 * @return mixed
 	 */
-	public function deleteFile( $key ) {
+	public function deleteBucketFile( $key ) {
 		try {
 			return $this->getClient()->deleteObject( array( 'Bucket' => $this->bucket, 'Key' => $key ) );
 		} catch ( \Exception $e ) {


### PR DESCRIPTION
Fix PHP Fatal error due to Declaration of deleteFile function is not compatible with the function in parent class

Close https://github.com/polevaultweb/s3-filesystem/issues/7