### PR TITLE
createBucket() now allow buckets to be created with Block All Public Access disabled

### DIFF
--- a/src/S3Filesystem.php
+++ b/src/S3Filesystem.php
@@ -120,7 +120,7 @@ class S3Filesystem extends Filesystem {
 	 * @throws \PHPUnit_Framework_AssertionFailedError
 	 */
 	public function createBucket( $block = false ) {
-		$args      = array( 'Bucket' => $this->bucket );
+		$args = array( 'Bucket' => $this->bucket );
 		if ( ! empty( $this->region ) ) {
 			$args['LocationConstraint'] = $this->region;
 		}


### PR DESCRIPTION
Resolves #9 

This PR adds the optional `$block` parameter to the `createBucket()` function.

|Value| Description|
|------|------------|
| false (default) | Create the bucket as it would have been created before April 2023. Both Block All Public Access and Enforce Object Ownership will be disabled.  |
| true|  Create the bucket as the new AWS default policy for creating buckets   |

Note that I opted to have `$block = false` as the default here since it will preserve the behavior as it were before the new AWS policy was enforced. This should cause the least amount of issues for anyone already using this Codeception module.
 